### PR TITLE
Add godotenv and load env variables in backend

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	_ "github.com/joho/godotenv/autoload"
 	"github.com/who-metrics/business/core"
 	"github.com/who-metrics/business/core/collectors/github"
 	"github.com/who-metrics/business/helpers"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -4,6 +4,8 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/shurcooL/githubv4 v0.0.0-20230305132112-efb623903184 h1:QwdHPs+b2raoqIDBgAkjYw89KHH2/CXbV+m2qrbDi9k=
 github.com/shurcooL/githubv4 v0.0.0-20230305132112-efb623903184/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=


### PR DESCRIPTION
## Description
Closes: https://github.com/sbv-world-health-org-metrics/sbv-world-health-org-metrics/issues/65

This PR uses the goDotenv package to automatically import the contents of a `.env` file into the environment.

I used the autoload package which will read in `.env`, but let me know if we want to have the option to load different files depending on the environment!

## Testing

I created a `.env` file locally with `FOO=bar`, added `fmt.Println("FOO:", os.Getenv("FOO"))` to `backend/business/core/collectors/github/fetchers/repos_info_fetcher.go`, and then ran the backend with `make build && ./backend/bin/metrics`.